### PR TITLE
Add verification route and expand wizard tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -18,12 +18,13 @@ const App = () => {
     <div className="App">
         <Router basename={process.env.PUBLIC_URL}>
           <Routes>
-            <Route exact path="/" element={<Verification/>} />
+            <Route path="/verification" element={<Verification />} />
             <Route path="/clientform" element={<ClientForm cuil={cuil} />} /> {/* Pass cuil as a prop */}
-            <Route exact path="/login" element={<Login />} />
-            <Route exact path="/reset" element={<Reset />} />
-            <Route exact path="/register" element={<Register />} />
-            <Route exact path="/report" element={<Report />} />
+            <Route path="/login" element={<Login />} />
+            <Route path="/reset" element={<Reset />} />
+            <Route path="/register" element={<Register />} />
+            <Route path="/report" element={<Report />} />
+            <Route path="/" element={<Verification />} />
           </Routes>
         </Router>
         </div>

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,38 +1,65 @@
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom'; // To mock routing in the app
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import App from './App';
+import { getDocs } from 'firebase/firestore';
 
-test('renders the banner component', () => {
-  render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
-  );
-  const bannerElement = screen.getByRole('banner'); // Assuming your banner has a role "banner"
-  expect(bannerElement).toBeInTheDocument();
+jest.mock('./firebase', () => ({ db: {} }));
+jest.mock('firebase/firestore', () => ({
+  collection: jest.fn(() => ({})),
+  getDocs: jest.fn(),
+  query: jest.fn(() => ({})),
+  where: jest.fn(() => ({})),
+}));
+
+describe('App routing and wizard', () => {
+  beforeEach(() => {
+    getDocs.mockResolvedValue({ forEach: () => {} });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('renders wizard on /verification route', () => {
+    window.history.pushState({}, 'Verification', '/verification');
+    render(<App />);
+    expect(screen.getByPlaceholderText(/Ingresa tu cuil/i)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('12')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('500000')).toBeInTheDocument();
+  });
+
+  test('step 1: shows error when CUIL is empty', async () => {
+    window.history.pushState({}, 'Verification', '/verification');
+    render(<App />);
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar crédito/i }));
+    expect(await screen.findByText(/CUIL no puede estar en blanco/i)).toBeInTheDocument();
+  });
+
+  test('step 2: shows error for invalid CUIL length', async () => {
+    window.history.pushState({}, 'Verification', '/verification');
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText(/Ingresa tu cuil/i), {
+      target: { value: '123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar crédito/i }));
+    expect(await screen.findByText(/Ingresa un CUIL válido/i)).toBeInTheDocument();
+  });
+
+  test('step 3: shows error when CUIL already registered', async () => {
+    const recentDate = new Date();
+    getDocs.mockResolvedValue({
+      forEach: (cb) => cb({ data: () => ({ timestamp: { toDate: () => recentDate } }) }),
+    });
+
+    window.history.pushState({}, 'Verification', '/verification');
+    render(<App />);
+    fireEvent.change(screen.getByPlaceholderText(/Ingresa tu cuil/i), {
+      target: { value: '20123456789' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Solicitar crédito/i }));
+    expect(
+      await screen.findByText(/El CUIL ya fue registrado en los últimos 30 días/i)
+    ).toBeInTheDocument();
+  });
 });
 
-test('renders verification form fields', () => {
-  render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
-  );
-  const cuilInput = screen.getByPlaceholderText(/Ingresa tu cuil/i); // Testing CUIL input
-  const cuotasRange = screen.getByLabelText(/Cantidad de Cuotas:/i); // Testing cuotas input
-  const montoRange = screen.getByLabelText(/Monto Solicitado:/i); // Testing monto input
-
-  expect(cuilInput).toBeInTheDocument();
-  expect(cuotasRange).toBeInTheDocument();
-  expect(montoRange).toBeInTheDocument();
-});
-
-test('renders the "Solicitar crédito" button', () => {
-  render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
-  );
-  const buttonElement = screen.getByRole('button', { name: /Solicitar crédito/i });
-  expect(buttonElement).toBeInTheDocument();
-});

--- a/src/pages/Verification.jsx
+++ b/src/pages/Verification.jsx
@@ -166,17 +166,17 @@ function Verification(props) {
         </button>
       </div>
 
-      {cuilError && 
+      {cuilError && (
       <div className="error-message_container">
       <div className="error-message">
         <div className="error-message_header">
           Error
         </div>
         <div className="error-message_body">
-      El CUIL ya fue registrado en los últimos 30 días. Solamente se puede ingresar una solicitud cada 30 días.
+      {cuilError}
         </div>
       </div>
-    </div>}
+    </div>)}
     
           {/* version actual del software */}
           <p className="version-text">


### PR DESCRIPTION
## Summary
- route /verification now renders the wizard
- show dynamic error messages
- add tests for verification flow and routing

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_68aeebd366e88333a7ab5204e1c7a50e